### PR TITLE
[critical] Precision lose for DECIMAL type in mysql

### DIFF
--- a/SchemaDumpController.php
+++ b/SchemaDumpController.php
@@ -199,8 +199,9 @@ class SchemaDumpController extends Controller
     private function otherDefinition($column)
     {
         $definition = '';
-
-        if (
+        if ($column->type == 'decimal' && strpos($column->dbType, 'decimal')) {
+            $definition .= substr($column->dbType, strlen('decimal'));
+        } elseif (
             ($column->size !== null && !$column->autoIncrement && $column->dbType !== 'tinyint(1)') ||
             ($column->size !== null && $column->unsigned)
         ) {

--- a/SchemaDumpController.php
+++ b/SchemaDumpController.php
@@ -199,7 +199,7 @@ class SchemaDumpController extends Controller
     private function otherDefinition($column)
     {
         $definition = '';
-        if ($column->type == 'decimal' && strpos($column->dbType, 'decimal')) {
+        if ($column->type == 'decimal' && strpos($column->dbType, 'decimal') === 0) {
             $definition .= substr($column->dbType, strlen('decimal'));
         } elseif (
             ($column->size !== null && !$column->autoIncrement && $column->dbType !== 'tinyint(1)') ||


### PR DESCRIPTION
When a column has a type of DECIMAL(19,4), the previous schemadump will output DECIMAL(19,0)

This bug of precision lose is critical

NOTE:
My fix has only been tested on MySQL